### PR TITLE
Deploy directly to GitHub Pages

### DIFF
--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -52,9 +52,8 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
-        working-directory: _dashboard/DotNetPerfMonitor/
         with:
-          path: ./dist
+          path: _dashboard/DotNetPerfMonitor/dist
 
   # Deployment job
   deploy:

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -6,7 +6,6 @@ name: Deploy to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
-  push:
     branches:
       - main
 

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -5,9 +5,7 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
-    branches:
-      - main
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -53,6 +51,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'G-Research/DotNetPerfMonitor' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -1,20 +1,40 @@
-name: Deploy to GitHub Pages
+# Sample workflow for building and deploying a Nuxt site to GitHub Pages
+#
+# To get started with Nuxt see: https://nuxtjs.org/docs/get-started/installation
+#
+name: Deploy Nuxt site to Pages
 
 on:
+  # Runs on pushes targeting the default branch
   push:
     branches:
       - main
+      # Branches used for testing - remove when production ready!
       - dashboard-setup
+      - gh-pages-deployment
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  # Build job
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Set up NodeJS
         uses: actions/setup-node@v2
@@ -30,9 +50,20 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
           pnpm run generate
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.9.3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        working-directory: _dashboard/DotNetPerfMonitor/
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          keep_files: true
-          publish_dir: _dashboard/DotNetPerfMonitor/dist
+          path: ./dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -2,16 +2,13 @@
 #
 # To get started with Nuxt see: https://nuxtjs.org/docs/get-started/installation
 #
-name: Deploy Nuxt site to Pages
+name: Deploy to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
   push:
     branches:
       - main
-      # Branches used for testing - remove when production ready!
-      - dashboard-setup
-      - gh-pages-deployment
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This workflow directly deploys to GH pages. It cannot be tested on a branch (Du to protection rules of the "github-pages" environment). LEt's merge it to "main" branch and see whether it works. It is an adapted workflow from the one that was suggested by the GH setting page:

```
# Sample workflow for building and deploying a Nuxt site to GitHub Pages
#
# To get started with Nuxt see: https://nuxtjs.org/docs/get-started/installation
#
name: Deploy Nuxt site to Pages

on:
  # Runs on pushes targeting the default branch
  push:
    branches: ["main"]

  # Allows you to run this workflow manually from the Actions tab
  workflow_dispatch:

# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
permissions:
  contents: read
  pages: write
  id-token: write

# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
concurrency:
  group: "pages"
  cancel-in-progress: false

jobs:
  # Build job
  build:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Detect package manager
        id: detect-package-manager
        run: |
          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
            echo "manager=yarn" >> $GITHUB_OUTPUT
            echo "command=install" >> $GITHUB_OUTPUT
            exit 0
          elif [ -f "${{ github.workspace }}/package.json" ]; then
            echo "manager=npm" >> $GITHUB_OUTPUT
            echo "command=ci" >> $GITHUB_OUTPUT
            exit 0
          else
            echo "Unable to determine package manager"
            exit 1
          fi
      - name: Setup Node
        uses: actions/setup-node@v3
        with:
          node-version: "16"
          cache: ${{ steps.detect-package-manager.outputs.manager }}
      - name: Setup Pages
        uses: actions/configure-pages@v3
        with:
          # Automatically inject router.base in your Nuxt configuration file and set
          # target to static (https://nuxtjs.org/docs/configuration-glossary/configuration-target/).
          #
          # You may remove this line if you want to manage the configuration yourself.
          static_site_generator: nuxt
      - name: Restore cache
        uses: actions/cache@v3
        with:
          path: |
            dist
            .nuxt
          key: ${{ runner.os }}-nuxt-build-${{ hashFiles('dist') }}
          restore-keys: |
            ${{ runner.os }}-nuxt-build-
      - name: Install dependencies
        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
      - name: Static HTML export with Nuxt
        run: ${{ steps.detect-package-manager.outputs.manager }} run generate
      - name: Upload artifact
        uses: actions/upload-pages-artifact@v2
        with:
          path: ./dist

  # Deployment job
  deploy:
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    runs-on: ubuntu-latest
    needs: build
    steps:
      - name: Deploy to GitHub Pages
        id: deployment
        uses: actions/deploy-pages@v2
```