### PR TITLE
Use baseURL for static assets (logo.png)

### DIFF
--- a/_dashboard/DotNetPerfMonitor/components/dashboard/left_sidebar.vue
+++ b/_dashboard/DotNetPerfMonitor/components/dashboard/left_sidebar.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import ref from 'vue'
 const mode = useColorMode()
-const src = mode.value === 'dark' ? '/images/logo.png' : '/images/logo-bg.png'
+const src = useRuntimeConfig().app.baseURL + (mode.value === 'dark' ? 'images/logo.png' : 'images/logo-bg.png')
 const links = [{
     label: 'Dashboard',
     icon: 'i-heroicons-squares-plus',


### PR DESCRIPTION
Solves the problem with building the correct url for fetching the `logo.png`.