### PR TITLE
Disable cron schedule 

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,8 +3,8 @@ name: benchmarks
 on:
   workflow_dispatch:
   pull_request:
-  schedule:
-    - cron: "0 */8 * * *" # Run workflow threee times a day
+#  schedule:
+#    - cron: "0 */8 * * *" # Run workflow threee times a day
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
We are disabling cron schedule, to make it easier to reorganize the repo layout.