### PR TITLE
Removing ASP.NET and xunit from the tabs

### DIFF
--- a/_dashboard/DotNetPerfMonitor/components/dashboard/tabs.vue
+++ b/_dashboard/DotNetPerfMonitor/components/dashboard/tabs.vue
@@ -43,5 +43,4 @@ import { ref } from 'vue'
 const config = await useDataConfig()
 useLogger("[CONFIG]", config.display)
 const _elements = computed(() => config.components)
-const categories = computed(() => ["NuGet", "MS Build", "F#", "C#",])
 </script>

--- a/_dashboard/DotNetPerfMonitor/public/app_config.json
+++ b/_dashboard/DotNetPerfMonitor/public/app_config.json
@@ -6,9 +6,7 @@
     { "uid": "nuget", "name": "NuGet" },
     { "uid": "msbuild", "name": "MSBuild" },
     { "uid": "fsharp", "name": "F#" },
-    { "uid": "csharp", "name": "C#" },
-    { "uid": "aspnet", "name": "ASP.NET" },
-    { "uid": "xunit", "name": "Xunit" }
+    { "uid": "csharp", "name": "C#" }
   ],
   "data": {
     "nuget": {


### PR DESCRIPTION
We are not planning to implement benchmarks for AP.NET or xUnit (at least for now).